### PR TITLE
Group foot

### DIFF
--- a/.lists/cfccfa4cde3b4d5bb2c1e6c2d816876b.tlist
+++ b/.lists/cfccfa4cde3b4d5bb2c1e6c2d816876b.tlist
@@ -1,5 +1,5 @@
 @General Todo
 ^none
 #cfccfa4cde3b4d5bb2c1e6c2d816876b
-!oSmooch Bubu all fucking day
--oSeriously, all day
+!oSmooch me some fucking BUBA
+-oheck yes!

--- a/change_prompt.py
+++ b/change_prompt.py
@@ -3,9 +3,10 @@ import urwid
 class ChangePrompt(urwid.WidgetWrap):
   
   signals = ['close']
-  def __init__(self, text):
+  def __init__(self, text, caption=None):
     self.reponse = ''
     self.edit = urwid.Edit(edit_text=text, align='center')
+    if caption: self.edit.set_caption(caption)
     self.map = urwid.AttrMap(self.edit, urwid.AttrSpec('h231', 'h160'))
     self.fill = urwid.Filler(self.map)
     super().__init__(self.fill)

--- a/group_foot.py
+++ b/group_foot.py
@@ -1,8 +1,55 @@
+from change_prompt import ChangePrompt
 from urwid import WidgetWrap, Edit, AttrMap, AttrSpec
+import urwid
 
 class GroupFoot(WidgetWrap):
   
   def __init__(self, group):
-    self.edit = Edit(caption='Group: ', edit_text=group, align='center')
-    self.map = AttrMap(self.edit, AttrSpec('', 'black'))
-    super().__init__(self.map)
+    self.group = _Group(group)
+    urwid.connect_signal(self.group, 'rebuild', self.build_stack)
+    self.holder = urwid.WidgetPlaceholder(None)
+    self.build_stack()
+    super().__init__(self.holder)
+
+  def edit(self):
+    self.group.start_edit()
+
+  def build_stack(self, obj=None):
+    pack = self.group.pack()[0]
+    length = pack if pack else 1
+    self.padding = urwid.Padding(self.group, 'center', length)
+    self.map = AttrMap(self.padding, AttrSpec('', 'black'))
+    self.holder.original_widget = self.map
+
+class _Group(urwid.PopUpLauncher):
+
+  signals = ['rebuild']
+  def __init__(self, group):
+    self.edit = urwid.Edit(caption='Group: ', edit_text=group, align='center')
+    super().__init__(self.edit)
+
+  def start_edit(self):
+    self.original_text = self.edit.edit_text
+    self.open_pop_up()
+
+  def create_pop_up(self):
+    prompt = ChangePrompt(self.edit.edit_text, caption=self.edit.caption)
+    urwid.connect_signal(prompt, 'close', self.confirm_change)
+    return prompt
+
+  def confirm_change(self, obj):
+    response = obj.response
+    if response == 'change':
+      self.close_pop_up() 
+      self.edit.set_edit_text(obj.edit.edit_text)
+      self.open_pop_up()
+    elif response == 'confirm':
+      self.original_text = self.edit.edit_text
+      self.close_pop_up()
+    elif response == 'cancel':
+      self.edit.set_edit_text(self.original_text)
+      self.close_pop_up()
+    self._emit('rebuild')
+
+  def get_pop_up_parameters(self):
+    return {'left': -1, 'top': 0, 'overlay_width': len(self.edit.text)+2, 'overlay_height': 1} 

--- a/main.py
+++ b/main.py
@@ -1,11 +1,25 @@
 from tlist_manager import TListManager
 import tlist_io
 import urwid 
+import signal
+import os
+
+#class SuspendProcess(Exception):
+#  pass
+
+#def suspend(signum, frame):
+#  raise SuspendProcess
+
+#signal.signal(signal.SIGTSTP, suspend)
 
 tlm = TListManager(tlist_io.load_list_data())
 loop = urwid.MainLoop(tlm, pop_ups=True)
-try:
-  loop.run()
-except KeyboardInterrupt:
-  tlm.save_and_quit()  
-  print('Goodbye!')
+running = True
+while running:
+  try:
+    loop.run()
+  except KeyboardInterrupt:
+    data = tlm.pull_list_data()  
+    tlist_io.save_all(data)
+    running = False
+print('Goodbye!')

--- a/title_bar.py
+++ b/title_bar.py
@@ -7,16 +7,15 @@ class TitleBar(urwid.WidgetWrap):
  
   def __init__(self, title):
     self.title = _Title(title)
-    urwid.connect_signal(self.title, 'rebuild', self.rebuild_stack)
-    self.padding = urwid.Padding(self.title, 'center', self.title.pack()[0])
-    self.map = AttrMap(self.padding, AttrSpec('yellow', 'black'))
-    self.holder = urwid.WidgetPlaceholder(self.map)
+    urwid.connect_signal(self.title, 'rebuild', self.build_stack)
+    self.holder = urwid.WidgetPlaceholder(None)
+    self.build_stack()
     super().__init__(self.holder)
 
-  def change(self):
-    self.title.change()
+  def edit(self):
+    self.title.start_edit()
 
-  def rebuild_stack(self, obj):
+  def build_stack(self, obj=None):
     pack = self.title.pack()[0]
     length = pack if pack else 1
     self.padding = urwid.Padding(self.title, 'center', length)
@@ -28,10 +27,9 @@ class _Title(urwid.PopUpLauncher):
   signals = ['rebuild']
   def __init__(self, title):
     self.text = urwid.Text(title, align='center')
-    self.holder = urwid.WidgetPlaceholder(self.text)
-    super().__init__(self.holder)
+    super().__init__(self.text)
 
-  def change(self):
+  def start_edit(self):
     self.original_text = self.text.text
     self.open_pop_up()
 

--- a/tlist.py
+++ b/tlist.py
@@ -60,9 +60,13 @@ class TList(WidgetWrap):
     self.body.remove(obj)
     self.index_tasks()
 
-#  def _write_buffer(self, task_data, data_buffer):
-#    task_data.append(data_buffer.copy())
-#    data_buffer.clear()
+  def set_edit(self, editing):
+    if editing:
+      self.is_editing = True
+      self.line_attr.set_focus_map({None: self.focus_ins})
+    else:
+      self.is_editing = False
+      self.line_attr.set_focus_map({None: self.focus_nav})
 
   def export(self):
     data = {'name': self.name, 'group': self.group, 'id': self.id, 'tasks': []}
@@ -86,8 +90,7 @@ class TList(WidgetWrap):
 
   def nav_keypress(self, size, key):
     if key == 'i':
-      self.is_editing = True
-      self.line_attr.set_focus_map({None: self.focus_ins})
+      self.set_edit(True)
     # Move focus up/down
     elif key == 'j':
       self.move_focus(1)
@@ -117,10 +120,9 @@ class TList(WidgetWrap):
       except AttributeError:
         pass
     elif key == 'n':
-      self.title.change()
+      self.title.edit()
     elif key == 'g':
-      self.list_frame.focus_position = 'footer'
-      self.is_editing = True
+      self.group_foot.edit()
     elif key == 'd':
       if self.list_box.focus:
         self.list_box.focus.prompt_delete() 
@@ -135,16 +137,17 @@ class TList(WidgetWrap):
         self.tasks.append(new_task)
         self.body.append(new_task)
       self.index_tasks()
+      self.set_edit(True)
     elif key == 't':
       if self.list_box.focus:
         focus = self.list_box.focus
         focus.new()
+        self.set_edit(True)
     else: return key
 
   def input_keypress(self, size, key):
     if (key == 'esc' or key == 'enter'):
-      self.is_editing = False
-      self.line_attr.set_focus_map({None: self.focus_nav})
+      self.set_edit(False)
       if self.list_frame.focus_position != 'body':
         self.name = self.title.edit.edit_text
         self.group = self.group_foot.edit.edit_text

--- a/tlist_io.py
+++ b/tlist_io.py
@@ -51,15 +51,18 @@ def parse_list(filename):
         data_buffer['expan'].append(line)
 
   if data_buffer: _write_buffer(tlist_data['tasks'], data_buffer)
-
   return tlist_data
 
 def _write_buffer(task_data, data_buffer):
   task_data.append(data_buffer.copy())
   data_buffer.clear()
 
+def save_all(tlist_data_list):
+  for tlist_data in tlist_data_list:
+    save_list(tlist_data)
+
 def save_list(tlist_data):
-  filename = '/home/desyn8686/Tudo/.lists/' + tlist_data['id'] + '.tlist'
+  filename = PATH + tlist_data['id'] + '.tlist'
   with open(filename, 'w') as f:
     f.write(LIST_OP + tlist_data['name'] + '\n')
     f.write(GROUP_OP + tlist_data['group'] + '\n')
@@ -70,7 +73,7 @@ def save_list(tlist_data):
         f.write(EXPAN_OP + line + '\n')
 
 def delete_list(tlist_id):
-  filename = '/home/desyn8686/Tudo/.lists/' + tlist_id + '.tlist'
+  filename = PATH + tlist_id + '.tlist'
   try:
     os.remove(filename)
   except FileNotFoundError:


### PR DESCRIPTION
Sticking with the overlay popup theme used with the title_bar editing, group_foot can now be set to edit by hitting 'g' in nav mode. Also did some light logic refactor and fixed save on interrupt.